### PR TITLE
Changed CSS transition on navbar to all, not just padding.

### DIFF
--- a/_includes/css/style.css
+++ b/_includes/css/style.css
@@ -236,10 +236,10 @@ fieldset[disabled] .btn-xl.active {
         padding: 25px 0;
         border: 0;
         background-color: transparent;
-        -o-transition: padding .3s;
-        -webkit-transition: padding .3s;
-        -moz-transition: padding .3s;
-        transition: padding .3s;
+        -o-transition: all .6s;
+        -webkit-transition: all .6s;
+        -moz-transition: all .6s;
+        transition: all .6s;
     }
 
     .navbar-default .navbar-brand {


### PR DESCRIPTION
It looks fairly strange that the background color appears instantly instead of transitioning. Additionally, the transition felt way too fast before. So, I've slowed it down to twice the time. It feels a lot less sudden to me with these changes.
