### PR TITLE
Simplify name adding instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,6 @@ Go to localhost:4000 to see the website.
 
 ### Want to add your name to this list?
 
-Here are the steps (using the branch workflow):
-
-1. Fork the repository (button up on the top right)
-2. Clone your fork: `git clone git@github.com:<your-username>/hackers-of-umass.github.io`
-3. Create a branch for your edits: `git checkout -b <your-username>/<branch-name>`
-4. Make your edits and commit them to that branch
-5. Switch back to the master branch and pull to see if any changes were made
-6. Switch back to your branch, and attempt to merge with master
-7. Fix conflicts if any, then push your changes
-8. Submit a pull request!
+1. [Fork, create a branch, and add your name to the list in `_config.yml`](https://github.com/hackers-of-umass/hackers-of-umass.github.io/edit/master/_config.yml)
+2. Propose a pull request with a helpful title like "Adding <your name> to the member list"
+3. Wait for an admin to merge it


### PR DESCRIPTION
I found at the github allows you to link directly to editing a specific file. This means it is a bit simpler to add your name, if you just click on that link, add your name to the list, and click "Propose file change".

What do you think of linking to this directly from the README?
